### PR TITLE
Version 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "econf"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "econf-derive",
  "log",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "econf-derive"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ In this example,
 * `PREFIX_X` is loaded to `x`
 * `PREFIX_Y` is loaded to `y`
 
+The environment variables are all upper-case with `_` separated.
+
 ## Why econf?
 
 There are some existing crates that provide similar features but `econf` is unique in the following ways:
@@ -105,7 +107,7 @@ In this example,
 * `PREFIX_V2_V2` is loaded to `a.v2.v2`
 
 Fields in child structs can be specified by chaining the field names with `_` as a separator.
-However, there's cases that names conflict. For example,
+However, there're cases that names conflict. For example,
 
 ```rust
 #[derive(LoadEnv)]

--- a/econf-derive/Cargo.toml
+++ b/econf-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "econf-derive"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Yushi OMOTE <yushiomote@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/econf/Cargo.toml
+++ b/econf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "econf"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Yushi OMOTE <yushiomote@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -14,7 +14,7 @@ readme = "README.md"
 log = "0.4"
 serde = "1.0"
 serde_yaml = "0.8"
-econf-derive = { version = "0.1.4", path = "../econf-derive" }
+econf-derive = { version = "0.2.0", path = "../econf-derive" }
 parse_duration = "1.0"
 
 [dev-dependencies]

--- a/econf/src/lib.rs
+++ b/econf/src/lib.rs
@@ -50,8 +50,8 @@
 //! There are some existing crates that provide similar features but `econf` is unique in the following ways:
 //!
 //! * **Supports nesting:** Supports nested structs in an intutive manner with a little constraint.
-//! * **Supports compound types:** Supports `tuple`, `Vec`, `HashMap` and various types.
-//! * **Supplemental:** Loads supplementally into existing variables in the code without changing the original logic.
+//! * **Supports containers:** Supports `Vec`, `HashMap` and various types.
+//! * **Supplemental:** Loads into existing variables in the code without changing the original logic.
 //! * **Contributor friendly:** Simple code base. Comprehensible with a little study on basic macro usage.
 //!
 //! # Supported types
@@ -63,8 +63,77 @@
 //! * Network: `IpAddr`,`Ipv4Addr`,`Ipv6Addr`,`SocketAddr`,`SocketAddrV4`,`SocketAddrV6`
 //! * Non-zero types: `NonZeroI128`,`NonZeroI16`,`NonZeroI32`,`NonZeroI64`,`NonZeroI8`,`NonZeroIsize`,`NonZeroU128`, `NonZeroU16`,`NonZeroU32`,`NonZeroU64`,`NonZeroU8`, `NonZeroUsize`
 //! * File system: `PathBuf`
-//! * Containers: `Vec`, `HashSet`, `HashMap`, `Option`, `BTreeMap`, `BTreeSet`, `BinaryHeap`, `LinkedList`, `VecDeque`
-//!     * Containers are parsed as YAML format. See [the tests](./econf/tests/basics.rs).
+//! * Containers: `Vec`, `HashSet`, `HashMap`, `Option`, `BTreeMap`, `BTreeSet`, `BinaryHeap`, `LinkedList`, `VecDeque`, `tuple`
+//!     * Containers are parsed as YAML format. See [the tests](https://github.com/YushiOMOTE/econf/blob/master/econf/tests/basics.rs).
+//!
+//! # Nesting
+//!
+//! Nested structs are supported.
+//!
+//! ```
+//! # use econf::LoadEnv;
+//! #[derive(LoadEnv)]
+//! struct A {
+//!     v1: usize,
+//!     v2: B,
+//! }
+//!
+//! #[derive(LoadEnv)]
+//! struct B {
+//!     v1: usize,
+//!     v2: usize,
+//! }
+//!
+//! fn main() {
+//!     let a = A {
+//!         v1: 1,
+//!         v2: B {
+//!             v1: 2,
+//!             v2: 3,
+//!         },
+//!     };
+//!
+//!     let a = econf::load(a, "PREFIX");
+//! }
+//! ```
+//!
+//! In this example,
+//!
+//! * `PREFIX_V1` is loaded to `a.v1`
+//! * `PREFIX_V2_V1` is loaded to `a.v2.v1`
+//! * `PREFIX_V2_V2` is loaded to `a.v2.v2`
+//!
+//! Fields in child structs can be specified by chaining the field names with `_` as a separator.
+//! However, there's cases that names conflict. For example,
+//!
+//! ```
+//! # use econf::LoadEnv;
+//! #[derive(LoadEnv)]
+//! struct A {
+//!     v2_v1: usize,
+//!     v2: B,
+//! }
+//!
+//! #[derive(LoadEnv)]
+//! struct B {
+//!     v1: usize,
+//!     v2: usize,
+//! }
+//!
+//! fn main() {
+//!     let a = A {
+//!         v2_v1: 1,
+//!         v2: B {
+//!             v1: 2,
+//!             v2: 3,
+//!         },
+//!     };
+//!
+//!     let a = econf::load(a, "PREFIX");
+//! }
+//! ```
+//!
+//! Here `PREFIX_V2_V1` corresponds to both `a.v2_v1` and `a.v2.v1`. In this case, `econf` prints warning through [`log facade`](https://docs.rs/log/latest/log/) and the value is loaded to both `a.v2_v1` and `a.v2.v1`.
 //!
 //! # Skipping fields
 //!
@@ -80,10 +149,7 @@
 //! }
 //! ```
 //!
-use log::*;
-use serde::de::DeserializeOwned;
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
-use std::fmt::Display;
+use std::collections::{BinaryHeap, BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
 use std::hash::Hash;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::num::{
@@ -91,15 +157,19 @@ use std::num::{
     NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
 };
 use std::path::PathBuf;
-use std::str::FromStr;
+
+use serde::de::DeserializeOwned;
 
 pub use econf_derive::LoadEnv;
 
+pub use crate::loader::Loader;
+
+mod loader;
+
 /// Makes the type loadable from environment variables.
 ///
-/// [`LoadEnv`](econf_derive::LoadEnv) derive macro automatically implements this trait. In the example below,
-/// the type `A` implements this trait and can be loaded by [`load`](load) method.
-/// Recommends to use the derive macro instead of manually implementing this trait.
+/// [`LoadEnv`](econf_derive::LoadEnv) derive macro automatically implements this trait. Therefore, usually no need to implement this trait manually.
+/// In the example below, the type `A` implements this trait and can be loaded by [`load`](load) method.
 ///
 /// ```rust
 /// # use econf::LoadEnv;
@@ -111,63 +181,44 @@ pub use econf_derive::LoadEnv;
 /// }
 /// ```
 ///
+/// The trait can be manually implemented.
+///
+/// ```
+/// use econf::{LoadEnv, Loader};
+///
+/// struct A {
+///     x: bool,
+/// }
+///
+/// impl LoadEnv for A {
+///
+///     fn load(self, path: &str, _loader: &mut Loader) -> Self {
+///         match std::env::var(path) {
+///             Ok(s) if s == "POSITIVE" => A { x: true },
+///             Ok(s) if s == "NEGATIVE" => A { x: false },
+///             Ok(_) | Err(_) => self,
+///         }
+///     }
+///
+/// }
+/// ```
+///
+/// `path` is the environment variable name to be loaded.
+/// Return a new value to override the original value (the original value is `self`).
+/// Return `self` to use the original value.
+///
 pub trait LoadEnv
-where
-    Self: Sized,
+    where
+        Self: Sized,
 {
-    fn load(self, path: &str, dup: &mut HashSet<String>) -> Self;
-}
-
-fn load_and_map<T, F, E>(value: T, path: &str, dup: &mut HashSet<String>, map: F) -> T
-where
-    F: FnOnce(&str) -> Result<T, E>,
-    E: Display,
-{
-    let path = path.to_uppercase();
-
-    if dup.get(&path).is_some() {
-        warn!("econf: warning: {} is ambiguous", path);
-    }
-    dup.insert(path.clone());
-
-    match std::env::var(path.clone()) {
-        Ok(s) => match map(&s) {
-            Ok(v) => {
-                info!("econf: loading {}: found {}", path, s);
-                v
-            }
-            Err(e) => {
-                error!("econf: loading {}: error on parsing \"{}\": {}", path, s, e);
-                value
-            }
-        },
-        Err(_) => {
-            info!("econf: loading {}: not found", path);
-            value
-        }
-    }
-}
-
-fn load_as_yaml<T>(value: T, path: &str, dup: &mut HashSet<String>) -> T
-where
-    T: DeserializeOwned,
-{
-    load_and_map(value, path, dup, |s| serde_yaml::from_str(s))
-}
-
-fn load_as_str<T>(value: T, path: &str, dup: &mut HashSet<String>) -> T
-where
-    T: FromStr,
-    T::Err: Display,
-{
-    load_and_map(value, path, dup, |s| T::from_str(s))
+    fn load(self, path: &str, loader: &mut Loader) -> Self;
 }
 
 macro_rules! impl_load_env {
     ($($t:ident),*) => {$(
         impl LoadEnv for $t {
-            fn load(self, path: &str, dup: &mut HashSet<String>) -> Self {
-                load_as_str(self, path, dup)
+            fn load(self, path: &str, loader: &mut Loader) -> Self {
+                loader.load_from_str(self, path)
             }
         }
     )*}
@@ -189,8 +240,8 @@ macro_rules! impl_load_env_containers {
         impl<$($p),*> LoadEnv for $t<$($p),*>
         where $( $p : $tb1 $(+ $tb2)* ),*
         {
-            fn load(self, path: &str, dup: &mut HashSet<String>) -> Self {
-                load_as_yaml(self, path, dup)
+            fn load(self, path: &str, loader: &mut Loader) -> Self {
+                loader.load_from_yaml(self, path)
             }
         }
     )*}
@@ -209,24 +260,24 @@ impl_load_env_containers! {
 }
 
 macro_rules! peel {
-    ($name:ident, $($other:ident,)*) => (tuple! { $($other,)* })
+    ($name:ident, $($other:ident,)*) => (impl_load_env_tuples! { $($other,)* })
 }
 
-macro_rules! tuple {
+macro_rules! impl_load_env_tuples {
     () => ();
     ( $($name:ident,)+ ) => (
         impl<$($name),*> LoadEnv for ($($name,)*)
             where $($name: DeserializeOwned,)*
         {
-            fn load(self, path: &str, dup: &mut HashSet<String>) -> Self {
-                load_as_yaml(self, path, dup)
+            fn load(self, path: &str, loader: &mut Loader) -> Self {
+                loader.load_from_yaml(self, path)
             }
         }
         peel! { $($name,)* }
     )
 }
 
-tuple! { T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }
+impl_load_env_tuples! { T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }
 
 /// Load environment variables to a struct.
 ///
@@ -258,15 +309,15 @@ tuple! { T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }
 /// ```
 ///
 pub fn load<T>(data: T, prefix: &str) -> T
-where
-    T: LoadEnv,
+    where
+        T: LoadEnv,
 {
-    let mut dup = HashSet::new();
-    data.load(prefix, &mut dup)
+    let mut loader = Loader::new();
+    data.load(prefix, &mut loader)
 }
 
 impl LoadEnv for std::time::Duration {
-    fn load(self, path: &str, dup: &mut HashSet<String>) -> Self {
-        load_and_map(self, path, dup, |s| parse_duration::parse(s))
+    fn load(self, path: &str, loader: &mut Loader) -> Self {
+        loader.load_and_map(self, path, |s| parse_duration::parse(s))
     }
 }

--- a/econf/src/lib.rs
+++ b/econf/src/lib.rs
@@ -45,6 +45,8 @@
 //! * `PREFIX_X` is loaded to `x`
 //! * `PREFIX_Y` is loaded to `y`
 //!
+//! The environment variables are all upper-case with `_` separated.
+//!
 //! # Why econf?
 //!
 //! There are some existing crates that provide similar features but `econf` is unique in the following ways:
@@ -104,7 +106,7 @@
 //! * `PREFIX_V2_V2` is loaded to `a.v2.v2`
 //!
 //! Fields in child structs can be specified by chaining the field names with `_` as a separator.
-//! However, there's cases that names conflict. For example,
+//! However, there're cases that names conflict. For example,
 //!
 //! ```
 //! # use econf::LoadEnv;

--- a/econf/src/lib.rs
+++ b/econf/src/lib.rs
@@ -151,7 +151,7 @@
 //! }
 //! ```
 //!
-use std::collections::{BinaryHeap, BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 use std::hash::Hash;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::num::{
@@ -210,8 +210,8 @@ mod loader;
 /// Return `self` to use the original value.
 ///
 pub trait LoadEnv
-    where
-        Self: Sized,
+where
+    Self: Sized,
 {
     fn load(self, path: &str, loader: &mut Loader) -> Self;
 }
@@ -311,8 +311,8 @@ impl_load_env_tuples! { T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }
 /// ```
 ///
 pub fn load<T>(data: T, prefix: &str) -> T
-    where
-        T: LoadEnv,
+where
+    T: LoadEnv,
 {
     let mut loader = Loader::new();
     data.load(prefix, &mut loader)

--- a/econf/src/loader.rs
+++ b/econf/src/loader.rs
@@ -1,0 +1,144 @@
+use std::collections::HashSet;
+use std::fmt::Display;
+use std::str::FromStr;
+
+use log::{error, info, warn};
+use serde::de::DeserializeOwned;
+
+/// Responsible for loading/parsing environment variables.
+pub struct Loader {
+    paths: HashSet<String>,
+}
+
+impl Loader {
+    /// Create the instance.
+    pub fn new() -> Self {
+        Self {
+            paths: HashSet::new(),
+        }
+    }
+
+    /// Check the name conflict of environment variables being loaded.
+    ///
+    /// ```
+    /// # use econf::Loader;
+    /// let mut loader = Loader::new();
+    ///
+    /// assert!(!loader.is_duplicated("PREFIX_X"));
+    /// assert!(!loader.is_duplicated("PREFIX_Y"));
+    /// assert!(loader.is_duplicated("PREFIX_X"));
+    /// ```
+    ///
+    pub fn is_duplicated(&mut self, path: &str) -> bool {
+        !self.paths.insert(path.into())
+    }
+
+    /// Loads an environment variable and overrides the original value if the value is successfully loaded.
+    ///
+    /// The function does the following:
+    ///
+    /// * Checks duplication (case insensitive)
+    /// * Loads a corresponding environment variable (look up `path` as upper-case)
+    /// * Calls `map` function to convert the loaded string to a specific type.
+    ///
+    /// If loading/conversion is successful, the function returns the new value loaded. Otherwise, returns `fallback_value`.
+    ///
+    /// ```
+    /// # use econf::Loader;
+    /// let mut loader = Loader::new();
+    ///
+    /// std::env::set_var("BAR", "2");
+    /// std::env::set_var("BUZZ", "A");
+    ///
+    /// assert_eq!(loader.load_and_map(1, "FOO", |v| v.parse()), 1);
+    /// assert_eq!(loader.load_and_map(1, "BAR", |v| v.parse()), 2);
+    /// assert_eq!(loader.load_and_map(1, "BUZZ", |v| v.parse()), 1);
+    /// ```
+    ///
+    pub fn load_and_map<T, F, E>(&mut self, fallback_value: T, path: &str, map: F) -> T
+        where
+            F: FnOnce(&str) -> Result<T, E>,
+            E: Display,
+    {
+        let path = path.to_uppercase();
+
+        if self.is_duplicated(&path) {
+            warn!("econf: warning: {} is ambiguous", path);
+        }
+
+        match std::env::var(&path) {
+            Ok(s) => match map(&s) {
+                Ok(v) => {
+                    info!("econf: loading {}: found {}", path, s);
+                    v
+                }
+                Err(e) => {
+                    error!("econf: loading {}: error on parsing \"{}\": {}", path, s, e);
+                    fallback_value
+                }
+            },
+            Err(_) => {
+                info!("econf: loading {}: not found", path);
+                fallback_value
+            }
+        }
+    }
+
+    /// Loads an environment variable in yaml format then deserializes it to a specific type.
+    ///
+    /// The function is used to load compound types and collections. Since the yaml is the superset of json,
+    /// the function is usable to parse json format.
+    ///
+    /// If loading/conversion is successful, the function returns the new value loaded. Otherwise, returns `fallback_value`.
+    ///
+    /// ```
+    /// # use econf::Loader;
+    /// # use std::collections::HashMap;
+    /// let mut loader = Loader::new();
+    ///
+    /// std::env::set_var("FOO", "[2, 2, 3]");
+    /// std::env::set_var("BAR", "{1: 3, 2: 2}");
+    /// std::env::set_var("BUZZ", "broken");
+    ///
+    /// assert_eq!(loader.load_from_yaml(vec![1usize, 2, 3], "FOO"), vec![2, 2, 3]);
+    /// assert_eq!(loader.load_from_yaml(vec![1usize, 2, 3], "FOO2"), vec![1, 2, 3]);
+    /// assert_eq!(loader.load_from_yaml(HashMap::from([(1usize, 1usize), (2, 2)]), "BAR"), HashMap::from([(1, 3), (2, 2)]));
+    /// assert_eq!(loader.load_from_yaml(HashMap::from([(1usize, 1usize), (2, 2)]), "BAR2"), HashMap::from([(1, 1), (2, 2)]));
+    /// assert_eq!(loader.load_from_yaml(vec![1usize, 2, 3], "BUZZ"), vec![1, 2, 3]);
+    /// ```
+    ///
+    pub fn load_from_yaml<T>(&mut self, fallback_value: T, path: &str) -> T
+        where
+            T: DeserializeOwned,
+    {
+        self.load_and_map(fallback_value, path, |s| serde_yaml::from_str(s))
+    }
+
+    /// Loads an environment variable then converts it to a specific type using [`from_str`](std::str::FromStr::from_str).
+    ///
+    /// If loading/conversion is successful, the function returns the new value loaded. Otherwise, returns `fallback_value`.
+    ///
+    /// ```
+    /// # use econf::Loader;
+    /// # use std::collections::HashMap;
+    /// let mut loader = Loader::new();
+    ///
+    /// std::env::set_var("FOO", "2");
+    /// std::env::set_var("BAR", "true");
+    /// std::env::set_var("BUZZ", "A");
+    ///
+    /// assert_eq!(loader.load_from_str(1, "FOO"), 2);
+    /// assert_eq!(loader.load_from_str(1, "FOO2"), 1);
+    /// assert_eq!(loader.load_from_str(false, "BAR"), true);
+    /// assert_eq!(loader.load_from_str(false, "BAR2"), false);
+    /// assert_eq!(loader.load_from_str(1, "BUZZ"), 1);
+    /// ```
+    ///
+    pub fn load_from_str<T>(&mut self, fallback_value: T, path: &str) -> T
+        where
+            T: FromStr,
+            T::Err: Display,
+    {
+        self.load_and_map(fallback_value, path, |s| T::from_str(s))
+    }
+}

--- a/readme.sh
+++ b/readme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 pushd econf
-cargo install cargo-readme
+cargo install cargo-readme --version 3.2.0
 cargo readme > ../README.md
 popd


### PR DESCRIPTION
* Introduce `Loader` to abstract duplication check, loading, parsing.
* Change `LoadEnv` trait interface which receives `Loader`
* Update documents

econf 0.1 and econf-derive 0.2 are not compatible and vice versa