### PR TITLE
Implement rename helper attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,5 +150,17 @@ struct A {
 }
 ```
 
+## Renaming fields
+
+Load a field with the given name instead of its Rust's field name. This is helpful if the environment variable name and Rust's field name don't match:
+
+```
+#[derive(LoadEnv)]
+struct A {
+    x: bool,
+    #[econf(rename = "ANOTHER_Y")]
+    y: u64, // will be loaded from an environment variable `ANOTHER_Y`
+}
+```
 
 License: MIT

--- a/econf/tests/basics.rs
+++ b/econf/tests/basics.rs
@@ -357,6 +357,40 @@ fn skipped() {
 }
 
 #[derive(LoadEnv)]
+struct NestedRenamed {
+    s: String,
+}
+
+#[derive(LoadEnv)]
+struct Renamed {
+    v1: bool,
+    #[econf(rename = "example_1")]
+    v2: u32,
+    #[econf(rename = "example_2")]
+    v3: NestedRenamed,
+}
+
+#[test]
+fn renamed() {
+    std::env::set_var("RENAMED_V1", "true");
+    std::env::set_var("RENAMED_EXAMPLE_1", "42");
+    std::env::set_var("RENAMED_EXAMPLE_2_S", "renamed text");
+
+    let a = Renamed {
+        v1: false,
+        v2: 0,
+        v3: NestedRenamed {
+            s: "initial".to_string(),
+        },
+    };
+
+    let a = econf::load(a, "renamed");
+    assert_eq!(a.v1, true);
+    assert_eq!(a.v2, 42);
+    assert_eq!(a.v3.s, "renamed text".to_string());
+}
+
+#[derive(LoadEnv)]
 struct Net {
     n1: IpAddr,
     n2: Ipv4Addr,


### PR DESCRIPTION
Thank you for the lovely crate! I implemented "rename" attribute like [`#[serde(rename)]`](https://serde.rs/field-attrs.html#rename) because I encountered the case I would like to separate field names and environment variable names.

## Overview
For instance, if we set an environment variable as `ENV_VARIABLE_A`, need to prepare the following Rust struct:

```rust
#[derive(LoadEnv)]
struct Example {
    env_variable_a: String,
}
```

Suppose we'd like to name the field as `a`. In this case, we can leverage the `rename` attribute:

```rust
#[derive(LoadEnv)]
struct Example {
    #[econf(rename = "env_variable_a")]
    a: String, // we can rename field's name as we like
}
```