### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To enable URL support, add the `url` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-econf = { version = "0.3", features = ["url"] }
+econf = { version = "0.3.1", features = ["url"] }
 ```
 
 With this feature enabled, you can load URLs from environment variables:

--- a/econf-derive/Cargo.toml
+++ b/econf-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "econf-derive"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Yushi OMOTE <yushiomote@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/econf/Cargo.toml
+++ b/econf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "econf"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Yushi OMOTE <yushiomote@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -14,7 +14,7 @@ readme = "README.md"
 log = "0.4"
 serde = "1.0"
 serde_yaml = "0.9"
-econf-derive = { version = "0.3.0", path = "../econf-derive" }
+econf-derive = { version = "0.3.1", path = "../econf-derive" }
 humantime = "2.1"
 url = { version = "2.5", optional = true }
 

--- a/econf/src/lib.rs
+++ b/econf/src/lib.rs
@@ -77,7 +77,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! econf = { version = "0.3", features = ["url"] }
+//! econf = { version = "0.3.1", features = ["url"] }
 //! ```
 //!
 //! With this feature enabled, you can load URLs from environment variables:


### PR DESCRIPTION
Bumps the version from 0.3.0 to 0.3.1 across the econf crate workspace, updating version numbers in package manifests and documentation.